### PR TITLE
Fix if syntax error for hive runQuery

### DIFF
--- a/engines/hive/bin/runQuery
+++ b/engines/hive/bin/runQuery
@@ -70,7 +70,7 @@ runModule () {
 
   echo "creating folders and setting permissions"
 		#dont delete/recreate result and temp folders if query is in debug mode: exception: step 1 of debug
-		if [ -z "$DEBUG_QUERY_PART" || $DEBUG_QUERY_PART -eq 1  ]
+		if [ -z "$DEBUG_QUERY_PART" ] || [ $DEBUG_QUERY_PART -eq 1 ]
   then
 		  #cannot run this hdfs commands in parallel, because it would break error handling
 				runCmdWithErrorCheck hadoop fs -rm -r -f -skipTrash "${RESULT_DIR}"


### PR DESCRIPTION
When run below command, it will throw out error on console:
./bin/bigBench runQuery -e hive -q 5
.....
/opt/benchmarks/Big-Data-Benchmark-for-Big-Bench/engines/hive/bin/runQuery: line 73: [: missing `]'
/opt/benchmarks/Big-Data-Benchmark-for-Big-Bench/engines/hive/bin/runQuery: line 73: : command not found