### PR TITLE
Support to transfer parameter within quotation mark in global or local engine setting

### DIFF
--- a/engines/hive/conf/engineSettings.conf
+++ b/engines/hive/conf/engineSettings.conf
@@ -10,7 +10,7 @@
 runEngineCmd () {
   if addInitScriptsToParams
   then
-    "$BINARY" $BINARY_PARAMS $INIT_PARAMS "$@"
+    echo "$BINARY_PARAMS $INIT_PARAMS $@" | xargs "$BINARY"
   else
     return 1
   fi

--- a/engines/hive/conf/engineSettings.conf
+++ b/engines/hive/conf/engineSettings.conf
@@ -10,7 +10,7 @@
 runEngineCmd () {
   if addInitScriptsToParams
   then
-    echo "$BINARY_PARAMS $INIT_PARAMS $@" | xargs "$BINARY"
+    eval "$BINARY" $BINARY_PARAMS $INIT_PARAMS "$@"
   else
     return 1
   fi


### PR DESCRIPTION
For current implementation, it don't support to transfer parameter  within quotation mark in "BINARY_PARAMS" since linux shell. For example, there is "--conf" option to specify parameter within double quotation mark, which the parameter include multiple value separated by white space(--conf "spark.executor.extraJavaOptions=-XX:NewRatio=1  -XX:SurvivorRatio=1") like below, it will error out "Unrecognized option: -XX:SurvivorRatio=1" when run Bigbench

Posted complete example:
BINARY_PARAMS='-v --driver-memory 4g --executor-memory 100g  --executor-cores 16 --num-executors 8 --conf  spark.yarn.executor.memoryOverhead=8192 --conf "spark.executor.extraJavaOptions=-XX:NewRatio=1  -XX:SurvivorRatio=1" --master yarn-client --jars /usr/lib/hive/lib/hive-common.jar,/usr/lib/hive/lib/hive-cli.jar,/usr/lib/hive/lib/hive-exec.jar,/usr/lib/hive/lib/hive-service.jar,/usr/lib/hive/lib/hive-metastore.jar,/usr/lib/hive/lib/libfb303-0.9.0.jar,/usr/lib/hive/lib/jdo-api-3.0.1.jar,/usr/lib/hive/lib/antlr-runtime-3.4.jar,/usr/lib/hive/lib/datanucleus-api-jdo-3.2.6.jar,/usr/lib/hive/lib/datanucleus-core-3.2.10.jar,/usr/lib/hive/lib/datanucleus-rdbms-3.2.9.jar,/usr/lib/hive/lib/derby-10.10.1.1.jar,/etc/hive/conf/hive-site.xml,/opt/Big-Bench/engines/hive/queries/Resources/bigbenchqueriesmr.jar,/opt/Big-Bench/engines/hive/queries/Resources/opennlp-maxent-3.0.3.jar,/opt/Big-Bench/engines/hive/queries/Resources/opennlp-tools-1.5.3.jar'

