### PR TITLE
fix wrong parameter name

### DIFF
--- a/engines/hive/conf/queryParameters.sql
+++ b/engines/hive/conf/queryParameters.sql
@@ -78,7 +78,7 @@ set q08_category=review;
 set q08_startDate=2001-09-02;
 -- + 1year
 set q08_endDate=2002-09-02;
-set q08_days_before_purchase=1;
+set q08_seconds_before_purchase=86400;
 
 
 -------- Q09 -----------


### PR DESCRIPTION
q08.sql uses "q08_seconds_before_purchase' parameter for the streaming script, however, this is not defined in queryParameters.sql and fails this query.
