### PR TITLE
fix q27 validation

### DIFF
--- a/engines/hive/queries/q27/run.sh
+++ b/engines/hive/queries/q27/run.sh
@@ -52,7 +52,7 @@ query_run_validate_method () {
 			echo "Validation failed: Query results are not OK"
 		fi
 	else
-		if [ `hadoop fs -cat "$RESULT_DIR/*" | head -n 10 | wc -l` -eq 1 ]
+		if [ `hadoop fs -cat "$RESULT_DIR/*" | head -n 10 | wc -l` -ge 1 ]
 		then
 			echo "Validation passed: Query returned results"
 		else


### PR DESCRIPTION
Q27 validation seems not correct that validation always fails as the query result has > 10 rows. Maybe it's better to use a more conservative check for this query.