### PR TITLE
Use 'ORDER BY' operation to globally order the results of  Q20, Q25 and Q26

### DIFF
--- a/engines/hive/queries/q20/q20.sql
+++ b/engines/hive/queries/q20/q20.sql
@@ -31,6 +31,15 @@
 set hive.exec.compress.output=false;
 set hive.exec.compress.output;
 
+-- This query requires parallel order by for fast and deterministic global ordering of final result
+set hive.optimize.sampling.orderby=${hiveconf:bigbench.hive.optimize.sampling.orderby};
+set hive.optimize.sampling.orderby.number=${hiveconf:bigbench.hive.optimize.sampling.orderby.number};
+set hive.optimize.sampling.orderby.percent=${hiveconf:bigbench.hive.optimize.sampling.orderby.percent};
+--debug print
+set hive.optimize.sampling.orderby;
+set hive.optimize.sampling.orderby.number;
+set hive.optimize.sampling.orderby.percent;
+
 DROP TABLE IF EXISTS ${hiveconf:TEMP_TABLE};
 CREATE TABLE ${hiveconf:TEMP_TABLE} (
   user_sk       BIGINT,
@@ -78,8 +87,9 @@ FROM
     FROM store_returns
     GROUP BY sr_customer_sk
   ) returned ON ss_customer_sk=sr_customer_sk
-CLUSTER BY user_sk
+--CLUSTER BY user_sk
 --no total ordering with ORDER BY required, further processed by clustering algorithm
+ORDER BY user_sk
 ;
 
 

--- a/engines/hive/queries/q25/q25.sql
+++ b/engines/hive/queries/q25/q25.sql
@@ -73,6 +73,15 @@ GROUP BY
 set hive.exec.compress.output=false;
 set hive.exec.compress.output;
 
+-- This query requires parallel order by for fast and deterministic global ordering of final result
+set hive.optimize.sampling.orderby=${hiveconf:bigbench.hive.optimize.sampling.orderby};
+set hive.optimize.sampling.orderby.number=${hiveconf:bigbench.hive.optimize.sampling.orderby.number};
+set hive.optimize.sampling.orderby.percent=${hiveconf:bigbench.hive.optimize.sampling.orderby.percent};
+--debug print
+set hive.optimize.sampling.orderby;
+set hive.optimize.sampling.orderby.number;
+set hive.optimize.sampling.orderby.percent;
+
 DROP TABLE IF EXISTS ${hiveconf:TEMP_RESULT_TABLE};
 CREATE TABLE ${hiveconf:TEMP_RESULT_TABLE} (
   cid        INT,
@@ -93,6 +102,7 @@ FROM ${hiveconf:TEMP_TABLE}
 GROUP BY cid 
 --CLUSTER BY cid --cluster by preceeded by group by is silently ignored by hive but fails in spark
 --no total ordering with ORDER BY required, further processed by clustering algorithm
+ORDER BY cid
 ;
 
 

--- a/engines/hive/queries/q26/q26.sql
+++ b/engines/hive/queries/q26/q26.sql
@@ -26,6 +26,15 @@
 set hive.exec.compress.output=false;
 set hive.exec.compress.output;
 
+-- This query requires parallel order by for fast and deterministic global ordering of final result
+set hive.optimize.sampling.orderby=${hiveconf:bigbench.hive.optimize.sampling.orderby};
+set hive.optimize.sampling.orderby.number=${hiveconf:bigbench.hive.optimize.sampling.orderby.number};
+set hive.optimize.sampling.orderby.percent=${hiveconf:bigbench.hive.optimize.sampling.orderby.percent};
+--debug print
+set hive.optimize.sampling.orderby;
+set hive.optimize.sampling.orderby.number;
+set hive.optimize.sampling.orderby.percent;
+
 DROP TABLE IF EXISTS ${hiveconf:TEMP_TABLE};
 CREATE TABLE ${hiveconf:TEMP_TABLE} (
   cid  INT,
@@ -73,6 +82,7 @@ GROUP BY ss.ss_customer_sk
 HAVING count(ss.ss_item_sk) > ${hiveconf:q26_count_ss_item_sk}
 --CLUSTER BY cid --cluster by preceeded by group by is silently ignored by hive but fails in spark
 --no total ordering with ORDER BY required, further processed by clustering algorithm
+ORDER BY cid
 ;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Hi,
For MLLIB port, the Q5, Q20, Q25, Q26 and Q28 can get correct engine validation result with 1GB data set on Hive on MapReduce engine. However, we found the Q20,Q25 and Q26 can't get the correct engine validation results on Hive on Spark and Hive on Tez (test environment is CDH 5.4.4 cluster). The potential cause is that the outputs of Hive SQL in Q20,Q25 and Q26 (as subsequent MLLIB inputs) were un-orderred, which have different implementation behavior compared with the outputs set on Hive on MR engine. So using the 'ORDER BY' clause to globally order the results and get correct results in two HOS and HOT engines.
