### PR TITLE
fix q14/q17 sql scripts for Spark 2.1.0+

### DIFF
--- a/engines/hive/queries/q14/q14.sql
+++ b/engines/hive/queries/q14/q14.sql
@@ -44,7 +44,7 @@ FROM (
   AND wp.wp_char_count >= ${hiveconf:q14_content_len_min}
   AND wp.wp_char_count <= ${hiveconf:q14_content_len_max}
 ) at
-JOIN (
+CROSS JOIN (
   SELECT COUNT(*) pmc
   FROM web_sales ws
   JOIN household_demographics hd ON ws.ws_ship_hdemo_sk = hd.hd_demo_sk

--- a/engines/hive/queries/q17/q17.sql
+++ b/engines/hive/queries/q17/q17.sql
@@ -47,7 +47,7 @@ FROM (
   AND d_moy = ${hiveconf:q17_month}
   AND (p_channel_dmail = 'Y' OR p_channel_email = 'Y' OR p_channel_tv = 'Y')
 ) promotional_sales
-JOIN (
+CROSS JOIN (
   SELECT SUM(ss_ext_sales_price) total
   FROM store_sales ss
   JOIN date_dim dd ON ss.ss_sold_date_sk = dd.d_date_sk


### PR DESCRIPTION
Spark requires the use of CROSS join syntax in SQL (and a new crossJoin DataFrame API) to specify explicit cartesian products between relations under the default configuration (spark.sql.crossJoin.enabled = false) since 2.1.0.

Reference: https://issues.apache.org/jira/browse/SPARK-17298